### PR TITLE
Feature/add wordpress compose

### DIFF
--- a/04/docker-compose.yml
+++ b/04/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+services:
+  db:
+    image: mysql:5.7
+    platform: linux/amd64
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpass
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wpuser
+      MYSQL_PASSWORD: wppass
+    volumes:
+      - db_data:/var/lib/mysql
+
+  wordpress:
+    image: wordpress:latest
+    platform: linux/amd64
+    ports:
+      - 8080:80
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_DB_USER: wpuser
+      WORDPRESS_DB_PASSWORD: wppass
+    depends_on:
+      - db
+
+volumes:
+  db_data:

--- a/Dockerfile/Dockerfile
+++ b/Dockerfile/Dockerfile
@@ -1,0 +1,20 @@
+# ビルドステージ
+FROM golang:alpine AS builder
+
+# 作業ディレクトリ作成
+WORKDIR /app
+
+# Goファイルをコンテナにコピー
+COPY main.go .
+
+# Goプログラムをビルド（静的リンクにする）
+RUN go build -o main main.go
+
+# 実行ステージ（軽量）
+FROM alpine
+
+# ビルド済みバイナリをコピー
+COPY --from=builder /app/main .
+
+# 実行コマンド
+CMD ["./main"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# server-masatoshi-mizofuchi
+# server-masatoshi-mizofuch

--- a/third_time_class/03/Dockerfile
+++ b/third_time_class/03/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.24-alpine3.22 AS builder
+
+WORKDIR /
+COPY main.go .
+RUN go build main.go
+
+FROM alpine:3.22
+
+COPY --from=builder / /
+
+CMD ["./main"]
+
+

--- a/third_time_class/03/main.go
+++ b/third_time_class/03/main.go
@@ -1,0 +1,9 @@
+// hello world の例
+// (公式サイト https://go.dev/ にある実装と同じ)
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, world!")
+}


### PR DESCRIPTION
## 概要
WordPress と MySQL を docker-compose により構築できるようにしました。

## 目的
Docker の学習と WordPress 環境のコンテナ化。
docker conpose で wordpress と DB のコンテナが動作する
起動した wordpress にアクセス出来る
wordpress のユーザーを作成できる
wordpress で記事を投稿できる
compose を終了ではなく停止してまた起動(restartでも可)しても wordpress の記事やユーザーが残っていることを確認する


## 動作確認
1. `docker-compose up -d` で起動
2. http://localhost:8080 にアクセスし、WordPress の初期設定が表示されることを確認
3. 投稿とユーザーを作成し、再起動後も保持されていることを確認
